### PR TITLE
Expose `*GraphRequest` functions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"net/http"
 	"sync"
 	"time"
 )
@@ -19,6 +20,8 @@ type Client interface {
 	// RequestCredentials.AccessTokenExpiresAt field to determine whether it should actually refresh
 	// the credentials or if the credentials are still valid.
 	RefreshCredentials() error
+
+	httpClient() *http.Client
 }
 
 // RequestCredentials stores all the information necessary to authenticate a request with the

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mhoc/msgoraph/scopes"
 )
 
+var _ Client = (*Headless)(nil)
+
 // Headless is used to authenticate requests in the context of a backend app. This is the most
 // common way for applications to authenticate with the api.
 type Headless struct {
@@ -20,6 +22,7 @@ type Headless struct {
 	RefreshToken       string
 	RequestCredentials *RequestCredentials
 	Scopes             scopes.Scopes
+	HTTPClient         *http.Client
 }
 
 // NewHeadless creates a new headless connection.
@@ -29,7 +32,12 @@ func NewHeadless(applicationID string, applicationSecret string, scopes scopes.S
 		ApplicationSecret:  applicationSecret,
 		RequestCredentials: &RequestCredentials{},
 		Scopes:             scopes,
+		HTTPClient:         http.DefaultClient,
 	}
+}
+
+func (h Headless) httpClient() *http.Client {
+	return h.HTTPClient
 }
 
 // Credentials returns back the set of credentials used for every request.

--- a/client/web_client.go
+++ b/client/web_client.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mhoc/msgoraph/scopes"
 )
 
+var _ Client = (*Web)(nil)
+
 // Web is used to authenticate requests in the context of an online/user-facing app, such
 // as a website. This type of client is mostly useful for debugging or for command line apps where
 // the user configures their own app on the Microsoft Graph portal. In a normal web app, the
@@ -32,6 +34,7 @@ type Web struct {
 	RefreshToken       string
 	RequestCredentials *RequestCredentials
 	Scopes             scopes.Scopes
+	HTTPClient         *http.Client
 }
 
 // NewWeb creates a new client.Web connection. To initialize the authentication on this, call
@@ -43,7 +46,12 @@ func NewWeb(applicationID string, applicationSecret string, redirectURIPort int,
 		LocalhostPort:      redirectURIPort,
 		RequestCredentials: &RequestCredentials{},
 		Scopes:             scopes,
+		HTTPClient:         http.DefaultClient,
 	}
+}
+
+func (w *Web) httpClient() *http.Client {
+	return w.HTTPClient
 }
 
 // Credentials returns back the set of request credentials in this client. Conforms to the

--- a/internal/doc.go
+++ b/internal/doc.go
@@ -1,3 +1,0 @@
-// Package internal contains logic which should rarely be accessed by consumers of this library,
-// primarily around forming HTTP/odata calls to the Microsoft Graph API.
-package internal

--- a/users/service.go
+++ b/users/service.go
@@ -1,12 +1,13 @@
 package users
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/mhoc/msgoraph/client"
-	"github.com/mhoc/msgoraph/internal"
 )
 
 // CreateUserRequest is all the available args you can set when creating a user.
@@ -81,7 +82,7 @@ type UpdateUserRequest struct {
 
 // CreateUser creates a new user in the tenant.
 func (s *ServiceContext) CreateUser(createUser CreateUserRequest) (User, error) {
-	body, err := internal.GraphRequest(s.client, "POST", "v1.0/users", nil, createUser)
+	body, err := client.GraphRequest(context.TODO(), s.client, http.MethodPost, "v1.0/users", nil, createUser)
 	var data GetUserResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
@@ -93,7 +94,7 @@ func (s *ServiceContext) CreateUser(createUser CreateUserRequest) (User, error) 
 // DeleteUser deletes an existing user by id or principal name.
 func (s *ServiceContext) DeleteUser(userIDOrPrincipal string) error {
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	_, err := internal.GraphRequest(s.client, "DELETE", reqURL, nil, nil)
+	_, err := client.GraphRequest(context.TODO(), s.client, http.MethodDelete, reqURL, nil, nil)
 	return err
 }
 
@@ -120,7 +121,7 @@ func (s *ServiceContext) GetUserWithFields(userIDOrPrincipal string, projection 
 	v := url.Values{}
 	v.Set("$select", selectFields)
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	b, err := internal.GraphRequest(s.client, "GET", reqURL, v, nil)
+	b, err := client.GraphRequest(context.TODO(), s.client, http.MethodGet, reqURL, v, nil)
 	var data GetUserResponse
 	err = json.Unmarshal(b, &data)
 	if err != nil {
@@ -140,7 +141,7 @@ func (s *ServiceContext) ListUsers() ([]User, error) {
 // UserAllFields, or customize it depending on what you want.
 func (s *ServiceContext) ListUsersWithFields(projection []Field) ([]User, error) {
 	getUserPage := func(url string) ([]User, string, error) {
-		b, err := internal.BasicGraphRequest(s.client, "GET", url)
+		b, err := client.BasicGraphRequest(context.TODO(), s.client, http.MethodGet, url, nil)
 		var data ListUsersResponse
 		err = json.Unmarshal(b, &data)
 		if err != nil {
@@ -175,6 +176,6 @@ func (s *ServiceContext) ListUsersWithFields(projection []Field) ([]User, error)
 // to update.
 func (s *ServiceContext) UpdateUser(userIDOrPrincipal string, u UpdateUserRequest) error {
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	_, err := internal.GraphRequest(s.client, "PATCH", reqURL, nil, u)
+	_, err := client.GraphRequest(context.TODO(), s.client, http.MethodPatch, reqURL, nil, u)
 	return err
 }


### PR DESCRIPTION
* Exposed `GraphRequest` and `BasicGraphRequest` functions so not-yet-supported APIs can be manually called.
* Support `context` in `*GraphRequest`
* Removed redundant code in `GraphRequest` (now calls `BasicGraphRequst` after the inital request prep)